### PR TITLE
Change to entry point to allow passing parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN ["pwsh", "-Command", "$ver = (Invoke-WebRequest -UseBasicParsing https://sto
 RUN chmod +x kubectl
 SHELL [ "pwsh" ]
 ADD logslurp.ps1 /opt/k
-CMD logslurp.ps1
+ENTRYPOINT logslurp.ps1 


### PR DESCRIPTION
allows for passing paramters like

`docker run -rm -v ~/.kube/config:/root/.kube/config -v $PWD/$3:/opt/k/out logslurp -win_user username -win_pass $pass`