### PR TITLE
Adding past Azure CNI logfiles

### DIFF
--- a/logslurp.ps1
+++ b/logslurp.ps1
@@ -27,6 +27,7 @@ $nodes.items | Where-Object { $_.metadata.labels.'beta.kubernetes.io/os' -eq 'wi
   $zipName = "$($_.status.nodeInfo.machineID)-$($timeStamp)_logs.zip"
   $remoteZipPath = Invoke-Command -Session $_.pssession {
     $paths = get-childitem c:\k\*.log -Exclude $using:lockedFiles
+    $paths += get-childitem c:\k\azure-vnet.log.*
     $paths += $using:lockedFiles | Foreach-Object { Copy-Item "c:\k\$_" . -Passthru }
     $scm = Get-WinEvent -FilterHashtable @{logname='System';ProviderName='Service Control Manager'} | Where-Object { $_.Message -Like "*docker*" -or $_.Message -Like "*kub*" } | Select-Object -Property TimeCreated, Id, LevelDisplayName, Message
     # 2004 = resource exhaustion, other 5 events related to reboots

--- a/logslurp.sh
+++ b/logslurp.sh
@@ -14,6 +14,7 @@ read -r -d '' remoteCommand <<'EOF'
     $zipName = "$(hostname)-$($timeStamp)_logs.zip";
 
     $paths = get-childitem c:\k\*.log -Exclude $lockedFiles;
+    $paths += get-childitem c:\k\azure-vnet.log.*;
     $paths += $lockedFiles | Foreach-Object { Copy-Item "c:\k\$_" . -Passthru };
     $scm = Get-WinEvent -FilterHashtable @{logname='System';ProviderName='Service Control Manager'} | Where-Object { $_.Message -Like "*docker*" -or $_.Message -Like "*kub*" } | Select-Object -Property TimeCreated, Id, LevelDisplayName, Message;
     $reboots = Get-WinEvent -FilterHashtable @{logname='System'; id=1074,1076,2004,6005,6006,6008} | Select-Object -Property TimeCreated, Id, LevelDisplayName, Message;


### PR DESCRIPTION
Azure CNI rolls over old logs with the pattern <logname>.log.N, rather than <logname>.N.log . This will capture them